### PR TITLE
Return numeric time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack.server
 Title: Example Outpack Server
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/api.R
+++ b/R/api.R
@@ -37,7 +37,9 @@ root <- function() {
 ##' @porcelain GET /metadata/list => json(list)
 ##'   state root :: root
 metadata_list <- function(root) {
-  root$index(refresh = TRUE)$location[c("packet", "time", "hash")]
+  ret <- root$index(refresh = TRUE)$location[c("packet", "time", "hash")]
+  ret$time <- as.numeric(unclass(ret$time))
+  ret
 }
 
 

--- a/inst/schema/README.md
+++ b/inst/schema/README.md
@@ -3,3 +3,16 @@ Some of the files here are updated from outpack itself, refresh with
 ```
 ./scripts/import_schema
 ```
+
+The schemas
+
+* `hash.json`
+* `id.json`
+* `metadata.json`
+
+are copied over, while
+
+* `list.json`
+* `root.json`
+
+have their canonical source here.

--- a/inst/schema/list.json
+++ b/inst/schema/list.json
@@ -8,7 +8,7 @@
                 "$ref": "id.json"
             },
             "time": {
-                "type": "string"
+                "type": "number"
             },
             "hash": {
                 "$ref": "hash.json"

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -29,6 +29,7 @@ test_that("Can list metadata", {
 
   cols <- c("packet", "time", "hash")
   expected <- root$index()$location[cols]
+  expected$time <- as.numeric(expected$time)
 
   expect_true(res$validated)
   expect_equal(res$content_type, "application/json")


### PR DESCRIPTION
We currently return a nicely formatted string, but it would be better to return just the number of seconds since 1970-01-01 as we have conversion functions for that and store that internally anyway.