### PR TITLE
Allow returning package metadata as plain text with no wrapper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack.server
 Title: Example Outpack Server
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     jsonlite,
     lgr,
     outpack,
-    porcelain
+    porcelain (>= 0.1.10)
 Suggests:
     httr,
     mockery,

--- a/R/api.R
+++ b/R/api.R
@@ -43,8 +43,23 @@ metadata_list <- function(root) {
 }
 
 
-##' @porcelain GET /metadata/<id> => json(metadata)
+## TODO: It might be nicer to have a single GET endpoint that flips
+## based on a header, but porcelain does not allow this!
+
+##' @porcelain GET /metadata/<id>/json => json(metadata)
 ##'   state root :: root
+metadata_get_json <- function(root, id) {
+  metadata_get(root, id)
+}
+
+
+##' @porcelain GET /metadata/<id>/text => text
+##'   state root :: root
+metadata_get_text <- function(root, id) {
+  metadata_get(root, id)
+}
+
+
 metadata_get <- function(root, id) {
   dat <- root$index()$location
   if (!any(dat$packet == id)) {

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -18,13 +18,22 @@
         returning = porcelain::porcelain_returning_json("list"),
         validate = validate)
     },
-    "GET /metadata/<id>" = function(state, validate) {
+    "GET /metadata/<id>/json" = function(state, validate) {
       porcelain::porcelain_endpoint$new(
         "GET",
-        "/metadata/<id>",
-        metadata_get,
+        "/metadata/<id>/json",
+        metadata_get_json,
         porcelain::porcelain_state(root = state$root),
         returning = porcelain::porcelain_returning_json("metadata"),
+        validate = validate)
+    },
+    "GET /metadata/<id>/text" = function(state, validate) {
+      porcelain::porcelain_endpoint$new(
+        "GET",
+        "/metadata/<id>/text",
+        metadata_get_text,
+        porcelain::porcelain_state(root = state$root),
+        returning = porcelain::porcelain_returning_text(),
         validate = validate)
     },
     "GET /file/<hash>" = function(state, validate) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,10 +10,14 @@ RUN apt-get update &&  apt-get install -y --no-install-recommends \
 # Without this, we are unable to pick up more recent packages
 COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
-COPY DESCRIPTION /tmp/DESCRIPTION
-
-RUN install2.r --error remotes &&  \
-        Rscript -e 'remotes::install_deps("/tmp")'
+RUN install2.r --error \
+        --repos https://packagemanager.rstudio.com/all/__linux__/focal/latest \
+        --repos https://mrc-ide.r-universe.dev \
+        docopt \
+        jsonlite \
+        lgr \
+        outpack \
+        porcelain
 
 EXPOSE 8001
 

--- a/tests/testthat/test-endpoints.R
+++ b/tests/testthat/test-endpoints.R
@@ -43,7 +43,7 @@ test_that("Can retrieve metadata", {
   meta <- root$metadata(id)
   hash <- meta$files$hash
 
-  endpoint <- outpack_server_endpoint("GET", "/metadata/<id>", root)
+  endpoint <- outpack_server_endpoint("GET", "/metadata/<id>/json", root)
   res <- endpoint$run(id)
   expect_true(res$validated)
   expect_identical(
@@ -54,10 +54,27 @@ test_that("Can retrieve metadata", {
 })
 
 
+test_that("Can retrieve metadata in plain text", {
+  root <- create_temporary_root(use_file_store = TRUE)
+  id <- create_random_packet(root)
+  meta <- root$metadata(id)
+  hash <- meta$files$hash
+
+  endpoint <- outpack_server_endpoint("GET", "/metadata/<id>/text", root)
+  res <- endpoint$run(id)
+  expect_true(res$validated)
+  expect_identical(
+    res$data,
+    json_string(read_string(file.path(root$path, ".outpack", "metadata", id))))
+  expect_equal(res$status_code, 200)
+  expect_equal(res$content_type, "text/plain")
+})
+
+
 test_that("Throw 404 if packet metadata not found", {
   root <- create_temporary_root(use_file_store = TRUE)
   id <- "20220812-141127-c568fb24"
-  endpoint <- outpack_server_endpoint("GET", "/metadata/<id>", root)
+  endpoint <- outpack_server_endpoint("GET", "/metadata/<id>/json", root)
   res <- endpoint$run(id)
 
   expect_equal(res$status_code, 404)


### PR DESCRIPTION
To improve https://github.com/mrc-ide/outpack/pull/28

There are two endpoints here, which is needed until we allow switching type on an accept header. The alternative would be to drop the json one entirely but it feels like it belongs still