### PR TITLE
mrc-3112 rename argument

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -32,18 +32,18 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -15,17 +15,17 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: any::pkgdown, local::
           needs: website
 
       - name: Deploy package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -15,15 +15,15 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: covr
+          extra-packages: any::covr
 
       - name: Test coverage
         run: covr::codecov()

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs
 .valgrind_ignore
 inst/doc
 pkgdown
+.idea

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     docopt,
     jsonlite,
     lgr,
-    outpack,
+    outpack (>= 0.2.0),
     porcelain (>= 0.1.10)
 Suggests:
     httr,

--- a/R/api.R
+++ b/R/api.R
@@ -37,7 +37,7 @@ root <- function() {
 ##' @porcelain GET /metadata/list => json(list)
 ##'   state root :: root
 metadata_list <- function(root) {
-  ret <- root$index(refresh = TRUE)$location[c("packet", "time", "hash")]
+  ret <- root$index(skip_cache = TRUE)$location[c("packet", "time", "hash")]
   ret$time <- as.numeric(unclass(ret$time))
   ret
 }

--- a/README.md
+++ b/README.md
@@ -412,6 +412,11 @@ To install `outpack.server`:
 remotes::install_github("mrc-ide/outpack.server", upgrade = FALSE)
 ```
 
+## Schema
+
+The `outpack` schema is imported into this package by running `./scripts/import_schema`, and needs to be 
+kept manually up to date by re-running that script as needed.
+
 ## License
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/inst/schema/metadata.json
+++ b/inst/schema/metadata.json
@@ -6,7 +6,7 @@
 
     "type": "object",
     "properties": {
-        "schemaVersion": {
+        "schema_version": {
             "description": "Schema version, used to manage migrations",
             "type": "string",
             "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
@@ -67,7 +67,7 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "id": {
+                    "packet": {
                         "$ref": "id.json"
                     },
                     "files": {
@@ -89,7 +89,7 @@
                         }
                     }
                 },
-                "required": ["id", "files"]
+                "required": ["packet", "files"]
             }
         },
 
@@ -110,5 +110,5 @@
             "description": "Information about the session; necessarily engine-specific format but in a standardised location"
         }
     },
-    "required": ["schemaVersion", "id", "name", "time", "files", "depends", "script", "custom", "session"]
+    "required": ["schema_version", "id", "name", "time", "files", "depends", "script", "custom", "session"]
 }

--- a/scripts/import_schema
+++ b/scripts/import_schema
@@ -5,4 +5,4 @@ if (pkgload::pkg_name(root) != "outpack.server") {
 }
 copy <- c("metadata.json", "id.json", "hash.json")
 src <- system.file(file.path("schema", copy), package = "outpack")
-fs::file_copy(src, file.path(root, "inst", "schema"))
+fs::file_copy(src, file.path(root, "inst", "schema"), overwrite = TRUE)


### PR DESCRIPTION
Reflect renamed argument in `outpack`.

There were a couple of test failures due to the outpack schema having been updated, so also updates the schema installed in this packge and adds instructions for doing so to the readme.